### PR TITLE
Make perfdata output honour -b option

### DIFF
--- a/plugins/check_snmp_mem.pl
+++ b/plugins/check_snmp_mem.pl
@@ -605,12 +605,10 @@ if (defined($o_netsnmp)) {
     }
     $n_output .= " ; " . $n_status;
     if (defined($o_perf)) {
-        if (defined($o_cache)) {
-            $n_output .= " | ram_used=" . ($$resultat{$nets_ram_total} - $$resultat{$nets_ram_free}) . ";";
-        } else {
-            $n_output .= " | ram_used="
-                . ($$resultat{$nets_ram_total} - $$resultat{$nets_ram_free} - $$resultat{$nets_ram_cache}) . ";";
-        }
+        my $perf_ramused = ($$resultat{$nets_ram_total} - $$resultat{$nets_ram_free});
+        $perf_ramused -= $$resultat{$nets_ram_cache} unless defined($o_cache);
+        $perf_ramused -= $$resultat{$nets_ram_buffer} if defined($o_buffer);
+        $n_output .= " | ram_used=$perf_ramused;";
         $n_output .= ($o_warnR == 0) ? ";" : round($o_warnR * $$resultat{$nets_ram_total} / 100, 0) . ";";
         $n_output .= ($o_critR == 0) ? ";" : round($o_critR * $$resultat{$nets_ram_total} / 100, 0) . ";";
         $n_output .= "0;" . $$resultat{$nets_ram_total} . " ";


### PR DESCRIPTION
Status output show RAM usage as percentage, while perfdata output shows total literal ram usage.  If `-N -m` options are given, cached memory is *included* in both the plugin status output and the perfdata.  If `-N -b` options are given, buffered memory is *excluded* from the status output, but remains *included* in the perfdata.

This patch alters the behaviour of the `-N -b` option combination so that, if supplied, buffered memory is also *excluded* from the perfdata.